### PR TITLE
Enable call to fps() anytime after start()

### DIFF
--- a/imutils/video/fps.py
+++ b/imutils/video/fps.py
@@ -30,4 +30,5 @@ class FPS:
 
 	def fps(self):
 		# compute the (approximate) frames per second
+		self._end = datetime.datetime.now()
 		return self._numFrames / self.elapsed()


### PR DESCRIPTION
At the moment, fps() can only be called after stop() (which sets self._end). By setting self._end inside fps() itself enables fps() to be called anytime. This means fps() can now be used at minimal cost anywhere in an image processing pipeline to provide immediate 'per frame' performance information.