### PR TITLE
fix order_points()

### DIFF
--- a/imutils/perspective.py
+++ b/imutils/perspective.py
@@ -10,24 +10,19 @@ def order_points(pts):
     # sort the points based on their x-coordinates
     xSorted = pts[np.argsort(pts[:, 0]), :]
 
-    # grab the left-most and right-most points from the sorted
-    # x-roodinate points
-    leftMost = xSorted[:2, :]
-    rightMost = xSorted[2:, :]
+    # sort the first 3 based on their y-coordinate,           
+    # this will give us our top-left point
+    (tl, a, b) = xSorted[np.argsort(xSorted[:-1][:, 1]), :]
+    rst = np.array([a, b, xSorted[-1]])
 
-    # now, sort the left-most coordinates according to their
-    # y-coordinates so we can grab the top-left and bottom-left
-    # points, respectively
-    leftMost = leftMost[np.argsort(leftMost[:, 1]), :]
-    (tl, bl) = leftMost
+    # sort the remainder by their y-coordinate
+    # giving us our top-right point     
+    (tr, a, b) = rst[np.argsort(rst[:, 1]), :]
+    rst = np.array([a, b])
 
-    # now that we have the top-left coordinate, use it as an
-    # anchor to calculate the Euclidean distance between the
-    # top-left and right-most points; by the Pythagorean
-    # theorem, the point with the largest distance will be
-    # our bottom-right point
-    D = dist.cdist(tl[np.newaxis], rightMost, "euclidean")[0]
-    (br, tr) = rightMost[np.argsort(D)[::-1], :]
+    # sort the last 2 on their x-coordinate to get the
+    # bottom-left and bottom-right points
+    (bl, br) = rst[np.argsort(rst[:, 0]), :]
 
     # return the coordinates in top-left, top-right,
     # bottom-right, and bottom-left order


### PR DESCRIPTION
Fixed the `order_points()` function for the semi-pathological case where you have a rectangle that is skewed so that the bottom 2 points are to the left of the top 2 points.  For instance, if you have a rectangle with coordinates `[[5, 1], [6,1], [2, 3], [1,3]]` (which is in clockwise-order) the old function will give you: `[[1, 3], [5, 1], [6, 1], [2, 3]]` which has the bottom-left point leading.
