### PR TITLE
Add 'videocapture' argument (default None) to VideoStream and WebcamV…

### DIFF
--- a/imutils/video/videostream.py
+++ b/imutils/video/videostream.py
@@ -3,7 +3,7 @@ from .webcamvideostream import WebcamVideoStream
 
 class VideoStream:
 	def __init__(self, src=0, usePiCamera=False, resolution=(320, 240),
-		framerate=32):
+		framerate=32, videocapture=None):
 		# check to see if the picamera module should be used
 		if usePiCamera:
 			# only import the picamera packages unless we are
@@ -20,7 +20,8 @@ class VideoStream:
 		# otherwise, we are using OpenCV so initialize the webcam
 		# stream
 		else:
-			self.stream = WebcamVideoStream(src=src)
+			self.stream = WebcamVideoStream(src=src,
+				videocapture=videocapture)
 
 	def start(self):
 		# start the threaded video stream

--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -3,10 +3,13 @@ from threading import Thread
 import cv2
 
 class WebcamVideoStream:
-	def __init__(self, src=0):
+	def __init__(self, src=0, videocapture=None):
 		# initialize the video camera stream and read the first frame
 		# from the stream
-		self.stream = cv2.VideoCapture(src)
+		if videocapture is None:
+			self.stream = cv2.VideoCapture(src)
+		else:
+			self.stream = videocapture
 		(self.grabbed, self.frame) = self.stream.read()
 
 		# initialize the variable used to indicate if the thread should


### PR DESCRIPTION
…ideoStream.

This allows the user to set capture properties (eg. width, height, fps, etc.)
beforehand. In this case, the 'src' argument is ignored.