### PR TITLE
Add feature to convert python list of numpy images to grid images

### DIFF
--- a/imutils/convenience.py
+++ b/imutils/convenience.py
@@ -184,8 +184,8 @@ def make_grids_of_images(image_list, image_shape, grid_shape):
     Empty space of incomplete grid images are filled with black pixels
     ---------------------------------------------------------------------------------------------
     :param image_list: python list of input images
-    :param image_shape: tuple, size each image will be resized to for display
-    :param grid_shape: tuple, shape of image grid (rows, cols)
+    :param image_shape: tuple, size each image will be resized to for display (width, height)
+    :param grid_shape: tuple, shape of image grid (width, height)
     :return: list of grid images in numpy array format
     ---------------------------------------------------------------------------------------------
 
@@ -193,8 +193,8 @@ def make_grids_of_images(image_list, image_shape, grid_shape):
 
     # load single image
     img = cv2.imread('lena.jpg')
-    # duplicate image 50 times
-    num_imgs = 50
+    # duplicate image 25 times
+    num_imgs = 25
     img_list = []
     for i in xrange(num_imgs):
         img_list.append(img)
@@ -238,4 +238,5 @@ def make_grids_of_images(image_list, image_shape, grid_shape):
     if start_new_img is False:
         image_grids.append(grid_image)  # add unfinished grid
     return image_grids
+
 

--- a/imutils/convenience.py
+++ b/imutils/convenience.py
@@ -173,3 +173,69 @@ def check_opencv_version(major, lib=None):
 def corners_to_keypoints(corners):
     """function to take the corners from cv2.GoodFeaturesToTrack and return cv2.KeyPoints"""
     return [cv2.KeyPoint(kp[0][0], kp[0][1], 1) for kp in corners]
+
+def make_grids_of_images(image_list, image_shape, grid_shape):
+    """
+    ---------------------------------------------------------------------------------------------
+    author: Kyle Hounslow
+    ---------------------------------------------------------------------------------------------
+    Converts a list of single images into a list of 'grid' images of specified rows and columns.
+    A new grid image is started once rows and columns of grid image is filled.
+    Empty space of incomplete grid images are filled with black pixels
+    ---------------------------------------------------------------------------------------------
+    :param image_list: python list of input images
+    :param image_shape: tuple, size each image will be resized to for display
+    :param grid_shape: tuple, shape of image grid (rows, cols)
+    :return: list of grid images in numpy array format
+    ---------------------------------------------------------------------------------------------
+
+    example usage:
+
+    # load single image
+    img = cv2.imread('lena.jpg')
+    # duplicate image 50 times
+    num_imgs = 50
+    img_list = []
+    for i in xrange(num_imgs):
+        img_list.append(img)
+    # convert image list into a grid of 256x256 images tiled in a 5x5 grid
+    grids = make_grids_of_images(img_list, (256, 256), (5, 5))
+    # iterate through grids and display
+    for grid in grids:
+        cv2.imshow('grid image', grid)
+        cv2.waitKey(0)
+
+    ----------------------------------------------------------------------------------------------
+    """
+    if len(image_shape) != 2:
+        raise Exception('image shape must be list or tuple of length 2 (rows, cols)')
+    if len(grid_shape) != 2:
+        raise Exception('grid shape must be list or tuple of length 2 (rows, cols)')
+    image_grids = []
+    # start with black canvas to draw images onto
+    grid_image = np.zeros(shape=(image_shape[1] * (grid_shape[1]), image_shape[0] * grid_shape[0], 3),
+                          dtype=np.uint8)
+    cursor_pos = [0, 0]
+    start_new_img = False
+    for img in image_list:
+        if type(img).__module__ != np.__name__:
+            raise Exception('input of type {} is not a valid numpy array'.format(type(img)))
+        start_new_img = False
+        img = cv2.resize(img, image_shape)
+        # draw image to black canvas
+        grid_image[cursor_pos[1]:cursor_pos[1] + image_shape[1], cursor_pos[0]:cursor_pos[0] + image_shape[0]] = img
+        cursor_pos[0] += image_shape[0]  # increment cursor x position
+        if cursor_pos[0] >= grid_shape[0] * image_shape[0]:
+            cursor_pos[1] += image_shape[1]  # increment cursor y position
+            cursor_pos[0] = 0
+            if cursor_pos[1] >= grid_shape[1] * image_shape[1]:
+                cursor_pos = [0, 0]
+                image_grids.append(grid_image)
+                # reset black canvas
+                grid_image = np.zeros(shape=(image_shape[1] * (grid_shape[1]), image_shape[0] * grid_shape[0], 3),
+                                      dtype=np.uint8)
+                start_new_img = True
+    if start_new_img is False:
+        image_grids.append(grid_image)  # add unfinished grid
+    return image_grids
+

--- a/imutils/convenience.py
+++ b/imutils/convenience.py
@@ -174,19 +174,19 @@ def corners_to_keypoints(corners):
     """function to take the corners from cv2.GoodFeaturesToTrack and return cv2.KeyPoints"""
     return [cv2.KeyPoint(kp[0][0], kp[0][1], 1) for kp in corners]
 
-def make_grids_of_images(image_list, image_shape, grid_shape):
+def build_mosaics(image_list, image_shape, mosaic_shape):
     """
     ---------------------------------------------------------------------------------------------
     author: Kyle Hounslow
     ---------------------------------------------------------------------------------------------
-    Converts a list of single images into a list of 'grid' images of specified rows and columns.
-    A new grid image is started once rows and columns of grid image is filled.
-    Empty space of incomplete grid images are filled with black pixels
+    Converts a list of single images into a list of 'mosaic' images of specified rows and columns.
+    A new mosaic image is started once rows and columns of mosaic image is filled.
+    Empty space of incomplete mosaic images are filled with black pixels
     ---------------------------------------------------------------------------------------------
     :param image_list: python list of input images
     :param image_shape: tuple, size each image will be resized to for display (width, height)
-    :param grid_shape: tuple, shape of image grid (width, height)
-    :return: list of grid images in numpy array format
+    :param mosaic_shape: tuple, shape of image mosaic (width, height)
+    :return: list of mosaic images in numpy array format
     ---------------------------------------------------------------------------------------------
 
     example usage:
@@ -198,22 +198,22 @@ def make_grids_of_images(image_list, image_shape, grid_shape):
     img_list = []
     for i in xrange(num_imgs):
         img_list.append(img)
-    # convert image list into a grid of 256x256 images tiled in a 5x5 grid
-    grids = make_grids_of_images(img_list, (256, 256), (5, 5))
-    # iterate through grids and display
-    for grid in grids:
-        cv2.imshow('grid image', grid)
+    # convert image list into a mosaic of 256x256 images tiled in a 5x5 mosaic
+    mosaics = make_mosaics_of_images(img_list, (256, 256), (5, 5))
+    # iterate through mosaics and display
+    for mosaic in mosaics:
+        cv2.imshow('mosaic image', mosaic)
         cv2.waitKey(0)
 
     ----------------------------------------------------------------------------------------------
     """
     if len(image_shape) != 2:
         raise Exception('image shape must be list or tuple of length 2 (rows, cols)')
-    if len(grid_shape) != 2:
-        raise Exception('grid shape must be list or tuple of length 2 (rows, cols)')
-    image_grids = []
+    if len(mosaic_shape) != 2:
+        raise Exception('mosaic shape must be list or tuple of length 2 (rows, cols)')
+    image_mosaics = []
     # start with black canvas to draw images onto
-    grid_image = np.zeros(shape=(image_shape[1] * (grid_shape[1]), image_shape[0] * grid_shape[0], 3),
+    mosaic_image = np.zeros(shape=(image_shape[1] * (mosaic_shape[1]), image_shape[0] * mosaic_shape[0], 3),
                           dtype=np.uint8)
     cursor_pos = [0, 0]
     start_new_img = False
@@ -223,20 +223,20 @@ def make_grids_of_images(image_list, image_shape, grid_shape):
         start_new_img = False
         img = cv2.resize(img, image_shape)
         # draw image to black canvas
-        grid_image[cursor_pos[1]:cursor_pos[1] + image_shape[1], cursor_pos[0]:cursor_pos[0] + image_shape[0]] = img
+        mosaic_image[cursor_pos[1]:cursor_pos[1] + image_shape[1], cursor_pos[0]:cursor_pos[0] + image_shape[0]] = img
         cursor_pos[0] += image_shape[0]  # increment cursor x position
-        if cursor_pos[0] >= grid_shape[0] * image_shape[0]:
+        if cursor_pos[0] >= mosaic_shape[0] * image_shape[0]:
             cursor_pos[1] += image_shape[1]  # increment cursor y position
             cursor_pos[0] = 0
-            if cursor_pos[1] >= grid_shape[1] * image_shape[1]:
+            if cursor_pos[1] >= mosaic_shape[1] * image_shape[1]:
                 cursor_pos = [0, 0]
-                image_grids.append(grid_image)
+                image_mosaics.append(mosaic_image)
                 # reset black canvas
-                grid_image = np.zeros(shape=(image_shape[1] * (grid_shape[1]), image_shape[0] * grid_shape[0], 3),
+                mosaic_image = np.zeros(shape=(image_shape[1] * (mosaic_shape[1]), image_shape[0] * mosaic_shape[0], 3),
                                       dtype=np.uint8)
                 start_new_img = True
     if start_new_img is False:
-        image_grids.append(grid_image)  # add unfinished grid
-    return image_grids
+        image_mosaics.append(mosaic_image)  # add unfinished mosaic
+    return image_mosaics
 
 


### PR DESCRIPTION
Hi Adrian,
I really like what you're doing with imutils and your blog, keep it up!
I'd like to submit a feature `make_grids_of_images` to imutils as part of the `convenience.py` module if you approve:  

**Brief:**
Often I need to crawl image datasets which have large, convoluted folder structures. I find it useful to create some grid images to visualise the dataset as well and share with my colleagues.  

**Example usage - "The Perfect Desktop Background":**
```
from imutils import convenience
import urllib
# get image from url, convert to numpy array
req = urllib.urlopen('https://avatars0.githubusercontent.com/u/7102778?v=3&s=460')
arr = np.asarray(bytearray(req.read()), dtype=np.uint8)
img = cv2.imdecode(arr, -1)
# duplicate image 'num_imgs' times
num_imgs = 35
img_list = []
for i in xrange(num_imgs):
    img_list.append(img)
# convert image list into a grid of 256x256 images tiled in a 7x5 grid
grids = convenience.make_grids_of_images(img_list, (256, 256), (7, 5))
# iterate through grids and display
for grid in grids:
    cv2.imshow('grid image', grid)
    cv2.waitKey(0)
```
Let me know what you think and feel free to refine/use as you wish.
Cheers,
Kyle
