### PR TITLE
fix Hue range

### DIFF
--- a/bin/range-detector
+++ b/bin/range-detector
@@ -23,7 +23,7 @@ def setup_trackbars(range_filter):
         v = 0 if i == "MIN" else 255
 
         for j in range_filter:
-            cv2.createTrackbar("%s_%s" % (j, i), "Trackbars", v, 255, callback)
+            cv2.createTrackbar("%s_%s" % (j, i), "Trackbars", v, 179 if j == 'H' else 255, callback)
 
 
 def get_arguments():


### PR DESCRIPTION
I noticed that the [official document](https://docs.opencv.org/3.2.0/df/d9d/tutorial_py_colorspaces.html) describes it this way: For HSV, Hue range is [0,179]