### PR TITLE
Fixed WebcamVideoStream not releasing camera when stopped.

### DIFF
--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -25,6 +25,7 @@ class WebcamVideoStream:
 		while True:
 			# if the thread indicator variable is set, stop the thread
 			if self.stopped:
+				self.stream.release()
 				return
 
 			# otherwise, read the next frame from the stream


### PR DESCRIPTION
This fixes issue #35.