### PR TITLE
Changed face_utils.shape_to_np to handle arbitrary number of landmarks

### DIFF
--- a/imutils/face_utils/helpers.py
+++ b/imutils/face_utils/helpers.py
@@ -31,7 +31,7 @@ def shape_to_np(shape, dtype="int"):
 	# initialize the list of (x, y)-coordinates
 	coords = np.zeros((shape.num_parts, 2), dtype=dtype)
 
-	# loop over the 68 facial landmarks and convert them
+	# loop over all facial landmarks and convert them
 	# to a 2-tuple of (x, y)-coordinates
 	for i in range(0, shape.num_parts):
 		coords[i] = (shape.part(i).x, shape.part(i).y)

--- a/imutils/face_utils/helpers.py
+++ b/imutils/face_utils/helpers.py
@@ -29,11 +29,11 @@ def rect_to_bb(rect):
 
 def shape_to_np(shape, dtype="int"):
 	# initialize the list of (x, y)-coordinates
-	coords = np.zeros((68, 2), dtype=dtype)
+	coords = np.zeros((shape.num_parts, 2), dtype=dtype)
 
 	# loop over the 68 facial landmarks and convert them
 	# to a 2-tuple of (x, y)-coordinates
-	for i in range(0, 68):
+	for i in range(0, shape.num_parts):
 		coords[i] = (shape.part(i).x, shape.part(i).y)
 
 	# return the list of (x, y)-coordinates


### PR DESCRIPTION
The change allows the `face_utils.shape_to_np` function to handle shape predictors with an arbitrary number of points instead of the hard-coded 68 landmarks.

The change is tested with the [5 landmark shape predictor](http://dlib.net/files/shape_predictor_5_face_landmarks.dat.bz2) as well as the [68 landmark predictor](http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2) from dlib.