### PR TITLE
use / instead of // in rotate_bound

### DIFF
--- a/imutils/convenience.py
+++ b/imutils/convenience.py
@@ -42,7 +42,7 @@ def rotate_bound(image, angle):
     # grab the dimensions of the image and then determine the
     # center
     (h, w) = image.shape[:2]
-    (cX, cY) = (w // 2, h // 2)
+    (cX, cY) = (w / 2, h / 2)
 
     # grab the rotation matrix (applying the negative of the
     # angle to rotate clockwise), then grab the sine and cosine


### PR DESCRIPTION
If you rotate the same image multiple times with rotate_bound, 
the image quality becomes worse.
This is prevented by using regular division.