### PR TITLE
- Changed imutils DENSE / GFTT / HARRIS factories to use masks

### DIFF
--- a/imutils/feature/dense.py
+++ b/imutils/feature/dense.py
@@ -1,18 +1,38 @@
 import cv2
+import imutils
 
 class DENSE:
     def __init__(self, step=6, radius=.5):
         self.step = step
         self.radius = radius
 
-    def detect(self, img):
+    def detect(self, img, mask=None):
+
+        xStart = 0
+        xEnd = img.shape[1]
+        yStart = 0
+        yEnd = img.shape[0]
+
+        # Mask
+        if mask is not None:
+            cnts = cv2.findContours(mask.copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            cnts = cnts[0] if imutils.is_cv2() else cnts[1]
+            peri = cv2.arcLength(cnts[0], True)
+            approx = cv2.approxPolyDP(cnts[0], 0.01 * peri, True)
+            (x, y, w, h) = cv2.boundingRect(approx)
+
+            xStart = x
+            xEnd = x + w
+            yStart = y
+            yEnd = y + h
+
         # initialize our list of keypoints
         kps = []
 
         # loop over the height and with of the image, taking a `step`
         # in each direction
-        for x in range(0, img.shape[1], self.step):
-            for y in range(0, img.shape[0], self.step):
+        for x in range(xStart, xEnd, self.step):
+            for y in range(yStart, yEnd, self.step):
                 # create a keypoint and add it to the keypoints list
                 kps.append(cv2.KeyPoint(x, y, self.radius))
 

--- a/imutils/feature/gftt.py
+++ b/imutils/feature/gftt.py
@@ -13,9 +13,10 @@ class GFTT:
         self.useHarrisDetector = useHarrisDetector
         self.k = k
 
-    def detect(self, img):
+    def detect(self, img, mask=None):
+        mask = self.mask if mask is None else mask
         cnrs = cv2.goodFeaturesToTrack(img, self.maxCorners, self.qualityLevel, self.minDistance,
-                                       mask=self.mask, blockSize=self.blockSize,
+                                       mask=mask, blockSize=self.blockSize,
                                        useHarrisDetector=self.useHarrisDetector, k=self.k)
 
         return corners_to_keypoints(cnrs)

--- a/imutils/feature/harris.py
+++ b/imutils/feature/harris.py
@@ -10,7 +10,11 @@ class HARRIS:
         self.k = k
         self.T = T
 
-    def detect(self, img):
+    def detect(self, img, mask=None):
+        # Mask
+        if mask is not None:
+            img = cv2.bitwise_and(img, mask)
+
         # convert our input image to a floating point data type and then
         # compute the Harris corner matrix
         gray = np.float32(img)


### PR DESCRIPTION
Allows us to pass a new mask when calling the detect() methods as we can do for:
['BRISK', 'DOG', 'SIFT', 'FAST', 'FASTHESSIAN', 'SURF', 'MSER', 'ORB', 'STAR']

The changes can be tested using the following program code:
https://github.com/kleysonr/opencv-sandbox/blob/master/python/features/video_features_matching.py

Best Regards.
Kleyson Rios.