### PR TITLE
Performance improvements for filevideostream

### DIFF
--- a/demos/read_frames_fast.py
+++ b/demos/read_frames_fast.py
@@ -1,0 +1,72 @@
+# Modified from: 
+# https://www.pyimagesearch.com/2017/02/06/faster-video-file-fps-with-cv2-videocapture-and-opencv/
+
+# Performance:
+#    Python 2.7: 105.78   --> 131.75
+#    Python 3.7:  15.36   -->  50.13
+
+# USAGE
+# python read_frames_fast.py --video videos/jurassic_park_intro.mp4
+
+# import the necessary packages
+from imutils.video import FileVideoStream
+from imutils.video import FPS
+import numpy as np
+import argparse
+import imutils
+import time
+import cv2
+
+def filterFrame(frame):
+	frame = imutils.resize(frame, width=450)
+	frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+	frame = np.dstack([frame, frame, frame])
+	return frame
+
+# construct the argument parse and parse the arguments
+ap = argparse.ArgumentParser()
+ap.add_argument("-v", "--video", required=True,
+	help="path to input video file")
+args = vars(ap.parse_args())
+
+# start the file video stream thread and allow the buffer to
+# start to fill
+print("[INFO] starting video file thread...")
+fvs = FileVideoStream(args["video"], transform=filterFrame).start()
+time.sleep(1.0)
+
+# start the FPS timer
+fps = FPS().start()
+
+# loop over frames from the video file stream
+while fvs.running():
+	# grab the frame from the threaded video file stream, resize
+	# it, and convert it to grayscale (while still retaining 3
+	# channels)
+	frame = fvs.read()
+
+	# Relocated filtering into producer thread with transform=filterFrame
+	#  Python 2.7: FPS 92.11 -> 131.36
+	#  Python 3.7: FPS 41.44 -> 50.11
+	#frame = filterFrame(frame)
+
+	# display the size of the queue on the frame
+	cv2.putText(frame, "Queue Size: {}".format(fvs.Q.qsize()),
+		(10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 0), 2)	
+
+	# show the frame and update the FPS counter
+	cv2.imshow("Frame", frame)
+
+	cv2.waitKey(1)
+	if fvs.Q.qsize() < 2:  # If we are low on frames, give time to producer
+		time.sleep(0.001)  # Ensures producer runs now, so 2 is sufficient
+	fps.update()
+
+# stop the timer and display FPS information
+fps.stop()
+print("[INFO] elasped time: {:.2f}".format(fps.elapsed()))
+print("[INFO] approx. FPS: {:.2f}".format(fps.fps()))
+
+# do a bit of cleanup
+cv2.destroyAllWindows()
+fvs.stop()

--- a/imutils/video/filevideostream.py
+++ b/imutils/video/filevideostream.py
@@ -2,6 +2,7 @@
 from threading import Thread
 import sys
 import cv2
+import time
 
 # import the Queue class from Python 3
 if sys.version_info >= (3, 0):
@@ -12,11 +13,12 @@ else:
 	from Queue import Queue
 
 class FileVideoStream:
-	def __init__(self, path, queueSize=128):
+	def __init__(self, path, transform=None, queueSize=128):
 		# initialize the file video stream along with the boolean
 		# used to indicate if the thread should be stopped or not
 		self.stream = cv2.VideoCapture(path)
 		self.stopped = False
+		self.transform = transform
 
 		# initialize the queue used to store frames read from
 		# the video file
@@ -48,12 +50,35 @@ class FileVideoStream:
 					self.stop()
 					return
 
+				# if there are transforms to be done, might as well
+				# do them on producer thread before handing back to
+				# consumer thread. ie. Usually the producer is so far
+				# ahead of consumer that we have time to spare.
+				#
+				# Python is not parallel but the transform operations
+				# are usually OpenCV native so release the GIL.
+				#
+				# Really just trying to avoid spinning up additional
+				# native threads and overheads of additional 
+				# producer/consumer queues since this one was generally
+				# idle grabbing frames.
+				if self.transform:
+					frame = self.transform(frame)
+
 				# add the frame to the queue
 				self.Q.put(frame)
+			else:
+				time.sleep(0.1)  # Rest for 10ms, we have a full queue  
 
 	def read(self):
 		# return next frame in the queue
 		return self.Q.get()
+
+	# Insufficient to have consumer use while(more()) which does
+	# not take into account if the producer has reached end of
+	# file stream. 
+	def running(self):
+		return self.Q.qsize() > 0 or not self.stopped
 
 	def more(self):
 		# return True if there are still frames in the queue


### PR DESCRIPTION
Tweaked the filevideostream to better account for Python 3.7. The new GIL in Python 3.2 changed the way in which the threads run which made the filevideostream update loop more expensive when queue was full. This change attempts to balance the thread activities to be more fair by sleeping when queue is full. Included some of my timings for Python 2.7 and Python 3.7... mostly I think the remaining differences are do to the cv.waitKey() (comment it out and try both before/after).  