### PR TITLE
added support for nvidia jetson camera

### DIFF
--- a/imutils/video/__init__.py
+++ b/imutils/video/__init__.py
@@ -4,3 +4,4 @@ from .fps import FPS
 from .videostream import VideoStream
 from .webcamvideostream import WebcamVideoStream
 from .filevideostream import FileVideoStream
+from .jetsonvideostream import JetsonVideoStream

--- a/imutils/video/jetsonvideostream.py
+++ b/imutils/video/jetsonvideostream.py
@@ -1,0 +1,55 @@
+# import the necessary packages
+from threading import Thread
+import cv2
+
+class JetsonVideoStream:
+	def __init__(self, resolution=(1920, 1080), name="JetsonVideoStream"):
+		# set up the gstreamer string used to set up the camera on 
+		# the jetson board
+		width = resolution[0]
+		height = resolution[1]
+		cameraString = ('nvcamerasrc ! '
+               			'video/x-raw(memory:NVMM), '
+               			'width=(int)2592, height=(int)1458, '
+               			'format=(string)I420, framerate=(fraction)30/1 ! '
+               			'nvvidconv ! '
+               			'video/x-raw, width=(int){}, height=(int){}, '
+               			'format=(string)BGRx ! '
+               			'videoconvert ! appsink').format(width, height)
+
+		# initialize the video camera stream using gstreamer and read 
+		# the first frame from the stream
+		self.stream = cv2.VideoCapture(cameraString, cv2.CAP_GSTREAMER)
+		(self.grabbed, self.frame) = self.stream.read()
+
+		# initialize the thread name
+		self.name = name
+
+		# initialize the variable used to indicate if the thread should
+		# be stopped
+		self.stopped = False
+
+	def start(self):
+		# start the thread to read frames from the video stream
+		t = Thread(target=self.update, name=self.name, args=())
+		t.daemon = True
+		t.start()
+		return self
+
+	def update(self):
+		# keep looping infinitely until the thread is stopped
+		while True:
+			# if the thread indicator variable is set, stop the thread
+			if self.stopped:
+				return
+
+			# otherwise, read the next frame from the stream
+			(self.grabbed, self.frame) = self.stream.read()
+
+	def read(self):
+		# return the frame most recently read
+		return self.frame
+
+	def stop(self):
+		# indicate that the thread should be stopped
+		self.stopped = True

--- a/imutils/video/videostream.py
+++ b/imutils/video/videostream.py
@@ -2,8 +2,7 @@
 from .webcamvideostream import WebcamVideoStream
 
 class VideoStream:
-	def __init__(self, src=0, usePiCamera=False, useJetsonCamera=False,
-		resolution=(320, 240), framerate=32):
+	def __init__(self, src=0, usePiCamera=False, resolution=(320, 240), framerate=32):
 		# check to see if the picamera module should be used
 		if usePiCamera:
 			# only import the picamera packages unless we are
@@ -16,10 +15,6 @@ class VideoStream:
 			# sensor to warmup
 			self.stream = PiVideoStream(resolution=resolution,
 				framerate=framerate)
-
-		elif useJetsonCamera:
-			from .jetsonvideostream import JetsonVideoStream
-			self.stream = JetsonVideoStream(resolution=resolution)
 
 		# otherwise, we are using OpenCV so initialize the webcam
 		# stream

--- a/imutils/video/videostream.py
+++ b/imutils/video/videostream.py
@@ -2,8 +2,8 @@
 from .webcamvideostream import WebcamVideoStream
 
 class VideoStream:
-	def __init__(self, src=0, usePiCamera=False, resolution=(320, 240),
-		framerate=32):
+	def __init__(self, src=0, usePiCamera=False, useJetsonCamera=False,
+		resolution=(320, 240), framerate=32):
 		# check to see if the picamera module should be used
 		if usePiCamera:
 			# only import the picamera packages unless we are
@@ -16,6 +16,10 @@ class VideoStream:
 			# sensor to warmup
 			self.stream = PiVideoStream(resolution=resolution,
 				framerate=framerate)
+
+		elif useJetsonCamera:
+			from .jetsonvideostream import JetsonVideoStream
+			self.stream = JetsonVideoStream(resolution=resolution)
 
 		# otherwise, we are using OpenCV so initialize the webcam
 		# stream


### PR DESCRIPTION
Hi,

I've added support to the videostream class for the in built nvidia jetson tx2 camera using gstreamer functionality.

I've provided a switch in the videostream class to enable this support in the same way as you do for the raspberry pi camera, but am happy to enable the support any other way.

Regards,

Alex