### PR TITLE
add GFTT to non contrib factory

### DIFF
--- a/imutils/feature/factories.py
+++ b/imutils/feature/factories.py
@@ -59,7 +59,8 @@ else:
         _DETECTOR_FACTORY = {"MSER": cv2.MSER_create,
                              "FAST": cv2.FastFeatureDetector_create,
                              "BRISK": cv2.BRISK_create,
-                             "ORB": cv2.ORB_create
+                             "ORB": cv2.ORB_create,
+                             "GFTT": GFTT
                              }
 
         _EXTRACTOR_FACTORY = {"ORB": cv2.ORB_create,

--- a/imutils/feature/factories.py
+++ b/imutils/feature/factories.py
@@ -60,7 +60,9 @@ else:
                              "FAST": cv2.FastFeatureDetector_create,
                              "BRISK": cv2.BRISK_create,
                              "ORB": cv2.ORB_create,
-                             "GFTT": GFTT
+                             "GFTT": GFTT,
+                             "HARRIS": HARRIS,
+                             "DENSE": DENSE
                              }
 
         _EXTRACTOR_FACTORY = {"ORB": cv2.ORB_create,


### PR DESCRIPTION
`cv2.goodFeaturesToTrack` is included in a typical install of OpenCV without contrib modules, but the current `try` `except` logic in [factories.py](https://github.com/jrosebr1/imutils/blob/master/imutils/feature/factories.py) excludes GFTT from being used unless contrib is also installed.

This PR adds `GFTT` to `_DETECTOR_FACTORY` so that it can be utilized without contrib.  I have tested the fix using a fresh virtualenv and the prebuilt [`opencv-python`](https://pypi.org/project/opencv-python/) from PyPi.

Please let me know if there is some reasoning I have missed that warrants GFTT being excluded when contrib is missing.

----

**Update**: added `HARRIS` & `DENSE` detectors to the non-contrib `_DETECTOR_FACTORY` as well.  They both should work without opencv_contrib.