### PR TITLE
Fix: Imutils freezes if file end reaches(Bug)

### DIFF
--- a/imutils/video/filevideostream.py
+++ b/imutils/video/filevideostream.py
@@ -39,7 +39,7 @@ class FileVideoStream:
 			# if the thread indicator variable is set, stop the
 			# thread
 			if self.stopped:
-				break
+				self.stopped = True
 
 			# otherwise, ensure the queue has room in it
 			if not self.Q.full():


### PR DESCRIPTION
Hello,
@jrosebr1 I encountered following bug in the latest PR #86: 

#### Bug:
Imutils freezes indefinitely if file(source) end reaches(without throwing any error), since there no rule to handle this exception.
####  Fix:
After applying my fix, we can now _check for File End and exit safely_ as follows:
```
from imutils.video import FileVideoStream
cam = FileVideoStream('/home/test.mp4').start()
while True: 
	frame = cam.read()
	if frame is None: #check for file end 
	      break  #safely breaks out if end reaches
cv2.destroyAllWindows()
cam.stop()
```
Thank you once again, Adrian :)