### PR TITLE
Convenience functions for cv2.putText

### DIFF
--- a/demos/text_demo.py
+++ b/demos/text_demo.py
@@ -1,0 +1,46 @@
+# author:    Adam Spannbauer
+
+# USAGE
+# python text_demo.py -i ../demo_images/bridge.jpg
+# python text_demo.py -i ../demo_images/bridge.jpg -c 0
+
+# import the necessary packages
+import argparse
+import cv2
+import imutils.text
+
+# construct the argument parser and parse the arguments
+ap = argparse.ArgumentParser()
+ap.add_argument("-i", "--image", required=True, help="path to input image")
+ap.add_argument("-c", "--center", default=1, type=int,
+                help="Contrast, positive value for more contrast")
+ap.add_argument("-x", default=5,
+                help="X coordinate for text. Used if center == 0")
+ap.add_argument("-y", default=25,
+                help="Y coordinate for text. Used if center == 0")
+args = vars(ap.parse_args())
+
+# read in image to draw text on
+image = cv2.imread(args['image'])
+
+if args['center']:
+    # draw centered text with a default font
+    imutils.text.put_centered_text(image,
+                                   'imutils.text\ndemo\noutput',
+                                   font_face=cv2.FONT_HERSHEY_SIMPLEX,
+                                   font_scale=1,
+                                   color=(0, 255, 0),
+                                   thickness=2)
+else:
+    # draw location specific text with a default font
+    imutils.text.put_text(image,
+                          'imutils.text\ndemo\noutput',
+                          (args['x'], args['y']),
+                          font_face=cv2.FONT_HERSHEY_SIMPLEX,
+                          font_scale=1,
+                          color=(0, 255, 0),
+                          thickness=2)
+
+# display resulting image with text
+cv2.imshow('Image with Text', image)
+cv2.waitKey(0)

--- a/imutils/text.py
+++ b/imutils/text.py
@@ -1,0 +1,107 @@
+import cv2
+
+
+def put_text(img, text, org, font_face, font_scale, color, thickness=1, line_type=8, bottom_left_origin=False):
+    """Utility for drawing text with line breaks
+
+    :param img: Image.
+    :param text: Text string to be drawn.
+    :param org: Bottom-left corner of the first line of the text string in the image.
+    :param font_face: Font type. One of FONT_HERSHEY_SIMPLEX, FONT_HERSHEY_PLAIN, FONT_HERSHEY_DUPLEX,
+                          FONT_HERSHEY_COMPLEX, FONT_HERSHEY_TRIPLEX, FONT_HERSHEY_COMPLEX_SMALL,
+                          FONT_HERSHEY_SCRIPT_SIMPLEX, or FONT_HERSHEY_SCRIPT_COMPLEX, where each of the font ID’s
+                          can be combined with FONT_ITALIC to get the slanted letters.
+    :param font_scale: Font scale factor that is multiplied by the font-specific base size.
+    :param color: Text color.
+    :param thickness: Thickness of the lines used to draw a text.
+    :param line_type: Line type. See the line for details.
+    :param bottom_left_origin: When true, the image data origin is at the bottom-left corner.
+                               Otherwise, it is at the top-left corner.
+    :return: None; image is modified in place
+    """
+    # Break out drawing coords
+    x, y = org
+
+    # Break text into list of text lines
+    text_lines = text.split('\n')
+
+    # Get height of text lines in pixels (height of all lines is the same)
+    _, line_height = cv2.getTextSize('', font_face, font_scale, thickness)[0]
+    # Set distance between lines in pixels
+    line_gap = line_height // 3
+
+    for i, text_line in enumerate(text_lines):
+        # Find total size of text block before this line
+        line_y_adjustment = i * (line_gap + line_height)
+
+        # Move text down from original line based on line number
+        if not bottom_left_origin:
+            line_y = y + line_y_adjustment
+        else:
+            line_y = y - line_y_adjustment
+
+        # Draw text
+        cv2.putText(img,
+                    text=text_lines[i],
+                    org=(x, line_y),
+                    fontFace=font_face,
+                    fontScale=font_scale,
+                    color=color,
+                    thickness=thickness,
+                    lineType=line_type,
+                    bottomLeftOrigin=bottom_left_origin)
+
+
+def put_centered_text(img, text, font_face, font_scale, color, thickness=1, line_type=8):
+    """Utility for drawing vertically & horizontally centered text with line breaks
+
+    :param img: Image.
+    :param text: Text string to be drawn.
+    :param font_face: Font type. One of FONT_HERSHEY_SIMPLEX, FONT_HERSHEY_PLAIN, FONT_HERSHEY_DUPLEX,
+                          FONT_HERSHEY_COMPLEX, FONT_HERSHEY_TRIPLEX, FONT_HERSHEY_COMPLEX_SMALL,
+                          FONT_HERSHEY_SCRIPT_SIMPLEX, or FONT_HERSHEY_SCRIPT_COMPLEX, where each of the font ID’s
+                          can be combined with FONT_ITALIC to get the slanted letters.
+    :param font_scale: Font scale factor that is multiplied by the font-specific base size.
+    :param color: Text color.
+    :param thickness: Thickness of the lines used to draw a text.
+    :param line_type: Line type. See the line for details.
+    :return: None; image is modified in place
+    """
+    # Save img dimensions
+    img_h, img_w = img.shape[:2]
+
+    # Break text into list of text lines
+    text_lines = text.split('\n')
+
+    # Get height of text lines in pixels (height of all lines is the same; width differs)
+    _, line_height = cv2.getTextSize('', font_face, font_scale, thickness)[0]
+    # Set distance between lines in pixels
+    line_gap = line_height // 3
+
+    # Calculate total text block height for centering
+    text_block_height = len(text_lines) * (line_height + line_gap)
+    text_block_height -= line_gap  # There's one less gap than lines
+
+    for i, text_line in enumerate(text_lines):
+        # Get width of text line in pixels (height of all lines is the same)
+        line_width, _ = cv2.getTextSize(text_line, font_face, font_scale, thickness)[0]
+
+        # Center line with image dimensions
+        x = (img_w - line_width) // 2
+        y = (img_h + line_height) // 2
+
+        # Find total size of text block before this line
+        line_adjustment = i * (line_gap + line_height)
+
+        # Adjust line y and re-center relative to total text block height
+        y += line_adjustment - text_block_height // 2 + line_gap
+
+        # Draw text
+        cv2.putText(img,
+                    text=text_lines[i],
+                    org=(x, y),
+                    fontFace=font_face,
+                    fontScale=font_scale,
+                    color=color,
+                    thickness=thickness,
+                    lineType=line_type)


### PR DESCRIPTION
Hi @jrosebr1,

I put together a PR per the discussion in #117.

The PR includes 2 functions and a demo file.

The 2 functions are:

* `imutils.text.put_text` - convenience function that works identically to `cv2.putText`, but respects line breaks as `\n`
* `imutils.text.put_centered_text` - convenience function that draws text centered vertically and horizontally and respects line breaks as `\n`

The functions share some logic, but I wrote them to be self-contained rather than perfectly unitized.  We can definitely revisit this design choice.

Another relevant design choice to bring up is argument naming.  I named the arguments to follow PEP8 standards (i.e. `font_scale` instead of `fontScale`). Would it be preferred for these argument names to mirror the `cv2.putText` naming conventions?

Below is output of both functions from the demo file using the test string: `'imutils.text\ndemo\noutput'`

* `imutils.text.put_text`
![image](https://user-images.githubusercontent.com/16326083/53031049-0a799b00-343a-11e9-8de9-f6cd18e983c8.png)

* `imutils.text.put_centered_text`
![image](https://user-images.githubusercontent.com/16326083/53031037-02216000-343a-11e9-9a1c-bec1028bb62d.png)

---

EDIT:

* An additional note is that I did not include the `bottom_left_origin` option in the `put_centered_text` function.