### PR TITLE
Add support for LAB to the range-detector

### DIFF
--- a/bin/range-detector
+++ b/bin/range-detector
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # USAGE: You need to specify a filter and "only one" image source
 #
@@ -42,7 +41,7 @@ def get_arguments():
     if not xor(bool(args['image']), bool(args['webcam'])):
         ap.error("Please specify only one image source")
 
-    if not args['filter'].upper() in ['RGB', 'HSV']:
+    if not args['filter'].upper() in ['RGB', 'HSV', 'LAB']:
         ap.error("Please speciy a correct filter.")
 
     return args

--- a/bin/range-detector
+++ b/bin/range-detector
@@ -29,7 +29,7 @@ def setup_trackbars(range_filter):
 def get_arguments():
     ap = argparse.ArgumentParser()
     ap.add_argument('-f', '--filter', required=True,
-                    help='Range filter. RGB or HSV')
+                    help='Range filter. RGB, HSV, or even LAB!')
     ap.add_argument('-i', '--image', required=False,
                     help='Path to the image')
     ap.add_argument('-w', '--webcam', required=False,
@@ -69,6 +69,8 @@ def main():
 
         if range_filter == 'RGB':
             frame_to_thresh = image.copy()
+        elif range_filter == 'LAB':
+            frame_to_thresh = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)
         else:
             frame_to_thresh = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
     else:


### PR DESCRIPTION
This pull request closes #131 
```
open -a XQuartz
ip=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
display_number=`ps -ef | grep "Xquartz :\d" | grep -v xinit | awk '{ print $9; }'`
/opt/X11/bin/xhost + $ip
```

`docker run -it --rm -e DISPLAY=$ip:0 -v /tmp/.X11-unix:/tmp/.X11-unix tensorflow-notebook /bin/bash`

```
jovyan@06db98bad969:~/test_bed$ ./imutils-master/bin/range-detector --filter LAB --image ../work/test.jpg --preview
```
## Pics or it didn't happen
![Screen Shot 2019-03-19 at 9 17 14 PM](https://user-images.githubusercontent.com/903532/54658839-a2e05b00-4a8c-11e9-858c-865930548f48.png)

