### PR TITLE
Fix FileVideoStream NoneType error when reaching end of file

### DIFF
--- a/imutils/video/filevideostream.py
+++ b/imutils/video/filevideostream.py
@@ -50,24 +50,24 @@ class FileVideoStream:
 				# reached the end of the video file
 				if not grabbed:
 					self.stopped = True
-					
-				# if there are transforms to be done, might as well
-				# do them on producer thread before handing back to
-				# consumer thread. ie. Usually the producer is so far
-				# ahead of consumer that we have time to spare.
-				#
-				# Python is not parallel but the transform operations
-				# are usually OpenCV native so release the GIL.
-				#
-				# Really just trying to avoid spinning up additional
-				# native threads and overheads of additional
-				# producer/consumer queues since this one was generally
-				# idle grabbing frames.
-				if self.transform:
-					frame = self.transform(frame)
+				else:
+					# if there are transforms to be done, might as well
+					# do them on producer thread before handing back to
+					# consumer thread. ie. Usually the producer is so far
+					# ahead of consumer that we have time to spare.
+					#
+					# Python is not parallel but the transform operations
+					# are usually OpenCV native so release the GIL.
+					#
+					# Really just trying to avoid spinning up additional
+					# native threads and overheads of additional
+					# producer/consumer queues since this one was generally
+					# idle grabbing frames.
+					if self.transform:
+						frame = self.transform(frame)
 
-				# add the frame to the queue
-				self.Q.put(frame)
+					# add the frame to the queue
+					self.Q.put(frame)
 			else:
 				time.sleep(0.1)  # Rest for 10ms, we have a full queue
 


### PR DESCRIPTION
## Problem

When using the FileVideoStream class to read a video file, reaching the end of the file raises an error similar to the following:

```
  File ".../python3.6/site-packages/imutils/convenience.py", line 69, in resize
    (h, w) = image.shape[:2]
AttributeError: 'NoneType' object has no attribute 'shape'
```

This is because the last frame returned by `FileVideoStream.read()` is not actually a frame, but `None`.


## Solution

When the end of the video file has been reached, the `frame` variable contains `None` (line 47). In this case, the frame should not be added to the queue.

The transform function shouldn't be executed either, as we're not sure whether this user-specified function can handle `None` as input for the frame.
