### PR TITLE
Fix dynamic fps()

### DIFF
--- a/imutils/video/fps.py
+++ b/imutils/video/fps.py
@@ -22,6 +22,7 @@ class FPS:
 		# increment the total number of frames examined during the
 		# start and end intervals
 		self._numFrames += 1
+		self._end = datetime.datetime.now()
 
 	def elapsed(self):
 		# return the total number of seconds between the start and


### PR DESCRIPTION
Allow fps() to dynamically get FPS value without having to call stop(), else it produces error, because _end is undefined.