### PR TITLE
PiCamera settings via kwargs

### DIFF
--- a/imutils/video/pivideostream.py
+++ b/imutils/video/pivideostream.py
@@ -5,11 +5,19 @@ from threading import Thread
 import cv2
 
 class PiVideoStream:
-	def __init__(self, resolution=(320, 240), framerate=32):
-		# initialize the camera and stream
+	def __init__(self, resolution=(320, 240), framerate=32, **kwargs):
+		# initialize the camera
 		self.camera = PiCamera()
+
+		# set camera parameters
 		self.camera.resolution = resolution
 		self.camera.framerate = framerate
+
+		# set optional camera parameters (refer to PiCamera docs)
+		for arg, value in kwargs.items():
+			setattr(self.camera, arg, value)
+
+		# initialize the stream
 		self.rawCapture = PiRGBArray(self.camera, size=resolution)
 		self.stream = self.camera.capture_continuous(self.rawCapture,
 			format="bgr", use_video_port=True)

--- a/imutils/video/pivideostream.py
+++ b/imutils/video/pivideostream.py
@@ -14,7 +14,7 @@ class PiVideoStream:
 		self.camera.framerate = framerate
 
 		# set optional camera parameters (refer to PiCamera docs)
-		for arg, value in kwargs.items():
+		for (arg, value) in kwargs.items():
 			setattr(self.camera, arg, value)
 
 		# initialize the stream

--- a/imutils/video/videostream.py
+++ b/imutils/video/videostream.py
@@ -3,7 +3,7 @@ from .webcamvideostream import WebcamVideoStream
 
 class VideoStream:
 	def __init__(self, src=0, usePiCamera=False, resolution=(320, 240),
-		framerate=32):
+		framerate=32, **kwargs):
 		# check to see if the picamera module should be used
 		if usePiCamera:
 			# only import the picamera packages unless we are
@@ -15,7 +15,7 @@ class VideoStream:
 			# initialize the picamera stream and allow the camera
 			# sensor to warmup
 			self.stream = PiVideoStream(resolution=resolution,
-				framerate=framerate)
+				framerate=framerate, **kwargs)
 
 		# otherwise, we are using OpenCV so initialize the webcam
 		# stream


### PR DESCRIPTION
Update for PiCamera video streams so that camera parameters can be set by the `vs.camera` object's `**kwargs`.