### PR TITLE
updated url_to_image function

### DIFF
--- a/imutils/convenience.py
+++ b/imutils/convenience.py
@@ -8,7 +8,7 @@ import sys
 
 # import any special Python 2.7 packages
 if sys.version_info.major == 2:
-    from urllib import urlopen
+    from urllib2 import urlopen
 
 # import any special Python 3 packages
 elif sys.version_info.major == 3:
@@ -132,7 +132,8 @@ def opencv2matplotlib(image):
 def url_to_image(url, readFlag=cv2.IMREAD_COLOR):
     # download the image, convert it to a NumPy array, and then read
     # it into OpenCV format
-    resp = urlopen(url)
+    req = ur.Request(url, headers={'User-Agent' : "Magic Browser"})
+    resp = urlopen(req)
     image = np.asarray(bytearray(resp.read()), dtype="uint8")
     image = cv2.imdecode(image, readFlag)
 


### PR DESCRIPTION
uses Request (with headers) now instead of directly attempting to urlopen the url

* Why we need this? The security settings on some websites will block the request otherwise (assuming it was made by a bot agent). 
* For python 2.7 we need to import urllib2 since we are using Request module.