### PR TITLE
Release Video Stream on stopping.

### DIFF
--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -28,6 +28,7 @@ class WebcamVideoStream:
 		while True:
 			# if the thread indicator variable is set, stop the thread
 			if self.stopped:
+				self.stream.release()
 				return
 
 			# otherwise, read the next frame from the stream


### PR DESCRIPTION
not releasing video stream on stopping was keeping webcam occupied by application.