### PR TITLE
Fixed order_points to have proper assumptions about quadrilateral shape

### DIFF
--- a/imutils/perspective.py
+++ b/imutils/perspective.py
@@ -5,7 +5,12 @@
 from scipy.spatial import distance as dist
 import numpy as np
 import cv2
+import math
 
+def angle(v1, v2):
+  return np.arccos(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
+
+# Assume a convex quadrilateral
 def order_points(pts):
     # sort the points based on their x-coordinates
     xSorted = pts[np.argsort(pts[:, 0]), :]
@@ -16,29 +21,27 @@ def order_points(pts):
     rightMost = xSorted[2:, :]
 
     # now, sort the left-most coordinates according to their
-    # y-coordinates so we can grab the top-left and bottom-left
-    # points, respectively
+    # y-coordinates so we can grab the top-left point
     leftMost = leftMost[np.argsort(leftMost[:, 1]), :]
-    (tl, bl) = leftMost
+    tl = leftMost[0]
+    # Get the remaining points in a list
+    rem = np.asarray([leftMost[1], *rightMost])
+    # Calcualte the angle of the vector formed by the top left
+    # point and each of the remaining points with the vector
+    # (1,0), a horizontal vector
+    angles = [angle(x - tl, [1,0]) for x in rem]
 
-    # now that we have the top-left coordinate, use it as an
-    # anchor to calculate the Euclidean distance between the
-    # top-left and right-most points; by the Pythagorean
-    # theorem, the point with the largest distance will be
-    # our bottom-right point
-    D = dist.cdist(tl[np.newaxis], rightMost, "euclidean")[0]
-    (br, tr) = rightMost[np.argsort(D)[::-1], :]
+    # Sort the remaining points by their angle to the origin point, 
+    # and then create the output array. 
+    return np.array([tl, *[x for _,x in sorted(zip(angles,rem))]], dtype="float32")
 
-    # return the coordinates in top-left, top-right,
-    # bottom-right, and bottom-left order
-    return np.array([tl, tr, br, bl], dtype="float32")
 
 def four_point_transform(image, pts):
     # obtain a consistent order of the points and unpack them
     # individually
     rect = order_points(pts)
     (tl, tr, br, bl) = rect
-
+    print("Rect: ", rect)
     # compute the width of the new image, which will be the
     # maximum distance between bottom-right and bottom-left
     # x-coordiates or the top-right and top-left x-coordinates
@@ -63,7 +66,7 @@ def four_point_transform(image, pts):
         [maxWidth - 1, 0],
         [maxWidth - 1, maxHeight - 1],
         [0, maxHeight - 1]], dtype="float32")
-
+    print("Dst: ", dst)
     # compute the perspective transform matrix and then apply it
     M = cv2.getPerspectiveTransform(rect, dst)
     warped = cv2.warpPerspective(image, M, (maxWidth, maxHeight))

--- a/imutils/perspective.py
+++ b/imutils/perspective.py
@@ -41,7 +41,6 @@ def four_point_transform(image, pts):
     # individually
     rect = order_points(pts)
     (tl, tr, br, bl) = rect
-    print("Rect: ", rect)
     # compute the width of the new image, which will be the
     # maximum distance between bottom-right and bottom-left
     # x-coordiates or the top-right and top-left x-coordinates
@@ -66,7 +65,6 @@ def four_point_transform(image, pts):
         [maxWidth - 1, 0],
         [maxWidth - 1, maxHeight - 1],
         [0, maxHeight - 1]], dtype="float32")
-    print("Dst: ", dst)
     # compute the perspective transform matrix and then apply it
     M = cv2.getPerspectiveTransform(rect, dst)
     warped = cv2.warpPerspective(image, M, (maxWidth, maxHeight))


### PR DESCRIPTION
The order_points function currently breaks when the assumption that the opposite point of a quadrilateral has the furthest euclidean distance from a queried point breaks. This assumption fails in some cases when the quadrilateral is a parallelogram, so the re-worked function calculates the angle of all of the points from the top-left anchor point, sorts them and orders the points that way. This function still requires that the quadrilateral is convex. 