### PR TITLE
Added borderValue parameter to rotate_bound().

### DIFF
--- a/imutils/convenience.py
+++ b/imutils/convenience.py
@@ -38,7 +38,7 @@ def rotate(image, angle, center=None, scale=1.0):
     # return the rotated image
     return rotated
 
-def rotate_bound(image, angle):
+def rotate_bound(image, angle, borderValue=0):
     # grab the dimensions of the image and then determine the
     # center
     (h, w) = image.shape[:2]
@@ -60,7 +60,7 @@ def rotate_bound(image, angle):
     M[1, 2] += (nH / 2) - cY
 
     # perform the actual rotation and return the image
-    return cv2.warpAffine(image, M, (nW, nH))
+    return cv2.warpAffine(image, M, (nW, nH), borderValue=borderValue)
 
 def resize(image, width=None, height=None, inter=cv2.INTER_AREA):
     # initialize the dimensions of the image to be resized and

--- a/imutils/convenience.py
+++ b/imutils/convenience.py
@@ -22,7 +22,7 @@ def translate(image, x, y):
     # return the translated image
     return shifted
 
-def rotate(image, angle, center=None, scale=1.0):
+def rotate(image, angle, center=None, scale=1.0, borderValue=0):
     # grab the dimensions of the image
     (h, w) = image.shape[:2]
 
@@ -33,10 +33,8 @@ def rotate(image, angle, center=None, scale=1.0):
 
     # perform the rotation
     M = cv2.getRotationMatrix2D(center, angle, scale)
-    rotated = cv2.warpAffine(image, M, (w, h))
-
-    # return the rotated image
-    return rotated
+    
+    return cv2.warpAffine(image, M, (w, h), borderValue=borderValue)
 
 def rotate_bound(image, angle, borderValue=0):
     # grab the dimensions of the image and then determine the


### PR DESCRIPTION
Hi!

This is such a useful package. I have been rotating images and wanted to have some control over the "extra space" revealed when the image is rotated. This is catered for by the `borderValue` parameter of the `warpAffine()` function.

This allows you to specify the "background colour" which is revealed when the image is rotated. By default this is black. Specifying `borderValue=(255, 255, 255)` will make this new portion of the image white.

Thanks,
Andrew.