### PR TITLE
Added release of cv2.VideoCapture class on stop

### DIFF
--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -28,6 +28,8 @@ class WebcamVideoStream:
 		while True:
 			# if the thread indicator variable is set, stop the thread
 			if self.stopped:
+				# release the video camera stream
+				self.stream.release()
 				return
 
 			# otherwise, read the next frame from the stream


### PR DESCRIPTION
When the WebcamVideoStream class is stopped, the underlying cv2.VideoCapture class isn't released properly (when starting the WebcamVideoStream class no frames are returned). By adding the self.stream.release() the cv2.VideoCapture class is released and the stated error is fixed