### PR TITLE
Enhancements to WebcamVideoStream (VideoCapture Properties and Release)

### DIFF
--- a/imutils/video/videostream.py
+++ b/imutils/video/videostream.py
@@ -3,7 +3,7 @@ from .webcamvideostream import WebcamVideoStream
 
 class VideoStream:
 	def __init__(self, src=0, usePiCamera=False, resolution=(320, 240),
-		framerate=32, **kwargs, cap=None):
+		framerate=32, **kwargs):
 		# check to see if the picamera module should be used
 		if usePiCamera:
 			# only import the picamera packages unless we are
@@ -17,11 +17,9 @@ class VideoStream:
 			self.stream = PiVideoStream(resolution=resolution,
 				framerate=framerate, **kwargs)
 
-		# otherwise, we are using OpenCV so initialize the webcam
-		# stream
+		# otherwise, we are using OpenCV so initialize the webcam stream
 		else:
-			self.stream = WebcamVideoStream(src=src, cap=cap,
-				resolution=resolution)
+			self.stream = WebcamVideoStream(src=src, resolution=resolution)
 
 	def start(self):
 		# start the threaded video stream

--- a/imutils/video/videostream.py
+++ b/imutils/video/videostream.py
@@ -17,7 +17,8 @@ class VideoStream:
 			self.stream = PiVideoStream(resolution=resolution,
 				framerate=framerate, **kwargs)
 
-		# otherwise, we are using OpenCV so initialize the webcam stream
+		# otherwise, we are using OpenCV so initialize the webcam
+		# stream
 		else:
 			self.stream = WebcamVideoStream(src=src, resolution=resolution)
 

--- a/imutils/video/videostream.py
+++ b/imutils/video/videostream.py
@@ -3,7 +3,7 @@ from .webcamvideostream import WebcamVideoStream
 
 class VideoStream:
 	def __init__(self, src=0, usePiCamera=False, resolution=(320, 240),
-		framerate=32, **kwargs):
+		framerate=32, **kwargs, cap=None):
 		# check to see if the picamera module should be used
 		if usePiCamera:
 			# only import the picamera packages unless we are
@@ -20,7 +20,8 @@ class VideoStream:
 		# otherwise, we are using OpenCV so initialize the webcam
 		# stream
 		else:
-			self.stream = WebcamVideoStream(src=src)
+			self.stream = WebcamVideoStream(src=src, cap=cap,
+				resolution=resolution)
 
 	def start(self):
 		# start the threaded video stream

--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -43,5 +43,6 @@ class WebcamVideoStream:
 		return self.frame
 
 	def stop(self):
+		self.stream.release()
 		# indicate that the thread should be stopped
 		self.stopped = True

--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -3,15 +3,16 @@ from threading import Thread
 import cv2
 
 class WebcamVideoStream:
-	def __init__(self, src=0, cap=None, resolution=(320, 240),
-		name="WebcamVideoStream"):
-		# initialize the video camera stream and read the first frame
-		# from the stream
-		self.stream = cap
-		if cap is None:
+	def __init__(self, src=0, resolution=(320, 240), name="WebcamVideoStream"):
+		# initialize the video camera stream
+		if isinstance(src, int):
 			self.stream = cv2.VideoCapture(src)
 			self.stream.set(3, int(resolution[0]))  # cv2.CAP_PROP_FRAME_WIDTH
 			self.stream.set(4, int(resolution[1]))  # cv2.CAP_PROP_FRAME_HEIGHT
+		else:
+			self.stream = src
+
+		# read the first frame from the stream
 		(self.grabbed, self.frame) = self.stream.read()
 
 		# initialize the thread name

--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -3,10 +3,15 @@ from threading import Thread
 import cv2
 
 class WebcamVideoStream:
-	def __init__(self, src=0, name="WebcamVideoStream"):
+	def __init__(self, src=0, cap=None, resolution=(320, 240),
+		name="WebcamVideoStream"):
 		# initialize the video camera stream and read the first frame
 		# from the stream
-		self.stream = cv2.VideoCapture(src)
+		self.stream = cap
+		if cap is not None:
+			self.stream = cv2.VideoCapture(src)
+			self.stream.set(3, int(resolution[0]))  # cv2.CAP_PROP_FRAME_WIDTH
+			self.stream.set(4, int(resolution[1]))  # cv2.CAP_PROP_FRAME_HEIGHT
 		(self.grabbed, self.frame) = self.stream.read()
 
 		# initialize the thread name

--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -8,7 +8,7 @@ class WebcamVideoStream:
 		# initialize the video camera stream and read the first frame
 		# from the stream
 		self.stream = cap
-		if cap is not None:
+		if cap is None:
 			self.stream = cv2.VideoCapture(src)
 			self.stream.set(3, int(resolution[0]))  # cv2.CAP_PROP_FRAME_WIDTH
 			self.stream.set(4, int(resolution[1]))  # cv2.CAP_PROP_FRAME_HEIGHT


### PR DESCRIPTION
Address a few limitations with WebcamVideoStream:

1.) Set resolution of the VideoCapture, or use a capture object with custom properties already set.
Based on feedback provided in #68 , the constructor has been improved to allow optional args for a VideoCapture object and a resolution tuple.
https://github.com/jrosebr1/imutils/pull/68#issuecomment-543759112

2.) Address #35 by releasing the VideoCapture when the WebcamVideoStream is stopped.

Thank you for the time you've already spent developing this awesome library.