### PR TITLE
Fixed helper crashing on face_utils.visualize_facial_landmarks(image,…

### DIFF
--- a/imutils/face_utils/helpers.py
+++ b/imutils/face_utils/helpers.py
@@ -80,7 +80,7 @@ def visualize_facial_landmarks(image, shape, colors=None, alpha=0.75):
 			for l in range(1, len(pts)):
 				ptA = tuple(pts[l - 1])
 				ptB = tuple(pts[l])
-				cv2.line(overlay, ptA, ptB, colors[i], 2)
+				cv2.line(overlay, ptA, ptB, colors[i - 1], 2)
 
 		# otherwise, compute the convex hull of the facial
 		# landmark coordinates points and display it


### PR DESCRIPTION
… shape)

Hello ! this is the first time i do this, so bear with me if i'm a little clueless.

So basically, i tried to follow this tutorial https://www.pyimagesearch.com/2017/04/10/detect-eyes-nose-lips-jaw-dlib-opencv-python/ and it crashed on the part showing the transparent face features.

I debugged it, and turns out it was this function. colors (line 83) was manipulated like it started from 1, not from 0; constantly throwing an out of range error.