### PR TITLE
Update filevideostream.py

### DIFF
--- a/imutils/video/filevideostream.py
+++ b/imutils/video/filevideostream.py
@@ -50,6 +50,7 @@ class FileVideoStream:
 				# reached the end of the video file
 				if not grabbed:
 					self.stopped = True
+					break
 					
 				# if there are transforms to be done, might as well
 				# do them on producer thread before handing back to


### PR DESCRIPTION
**break** statement is required to immediately come out of While loop when "**not grabbed**" is TRUE. Since break is not there, so it goes ahead with putting None type object in Queue, which results in error as None Type object is dequeued in last dequeue operation.