### PR TITLE
Update pivideostream.py

### DIFF
--- a/imutils/video/pivideostream.py
+++ b/imutils/video/pivideostream.py
@@ -5,10 +5,11 @@ from threading import Thread
 import cv2
 
 class PiVideoStream:
-	def __init__(self, resolution=(320, 240), framerate=32, **kwargs):
+	def __init__(self, rotation=0, resolution=(320, 240), framerate=32, **kwargs):
 		# initialize the camera
 		self.camera = PiCamera()
-
+		self.camera.rotation = rotation
+		
 		# set camera parameters
 		self.camera.resolution = resolution
 		self.camera.framerate = framerate


### PR DESCRIPTION
Add code to set the PiCamera rotation.  The default value is 0 but values can range from 0-360.  0 and 180 are typical settings

This PR relies on PR44 with updates to videostream.py