### PR TITLE
[webcamvideostream.py] updated to allow another start() after a stop()

### DIFF
--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -40,3 +40,5 @@ class WebcamVideoStream:
 	def stop(self):
 		# indicate that the thread should be stopped
 		self.stopped = True
+		# release the camera stream
+		self.stream.release()


### PR DESCRIPTION
When calling .stop() the stream should be released. 
In the original code the stream was not released. This makes it impossible to .start() the stream again after a .stop()