### PR TITLE
Fixed FATAL: exception not rethrown in webcamvideostream

### DIFF
--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -11,6 +11,10 @@ class WebcamVideoStream:
 
 		# initialize the thread name
 		self.name = name
+		
+		# intialize thread
+		self.thread = Thread(target=self.update, name=self.name, args=())
+		self.thread.daemon = True
 
 		# initialize the variable used to indicate if the thread should
 		# be stopped
@@ -18,9 +22,8 @@ class WebcamVideoStream:
 
 	def start(self):
 		# start the thread to read frames from the video stream
-		t = Thread(target=self.update, name=self.name, args=())
-		t.daemon = True
-		t.start()
+
+		self.thread.start()
 		return self
 
 	def update(self):
@@ -40,3 +43,6 @@ class WebcamVideoStream:
 	def stop(self):
 		# indicate that the thread should be stopped
 		self.stopped = True
+
+		# wait until stream resources are released (producer thread might be still grabbing frame)
+		self.thread.join()


### PR DESCRIPTION
Hi there.
I've fixed the threading issue mentioned in #164 in webcamvideostream.py that was closed as a cv2 bug.

A similar issue was in filevideostream.py that was fixed in #86, but webcamvideostream.py was left unfixed as a cv2 bug.
Please check and merge :)

Sincere regards