### PR TITLE
camera release

### DIFF
--- a/imutils/video/webcamvideostream.py
+++ b/imutils/video/webcamvideostream.py
@@ -40,3 +40,4 @@ class WebcamVideoStream:
 	def stop(self):
 		# indicate that the thread should be stopped
 		self.stopped = True
+		self.stream.release() #also release the camera


### PR DESCRIPTION
In some hardware, the camera isn't released.
Especially when working with Jupyter notebook, Kernel is required to be restarted every time for a new run.
Adding stream.release() solves the above issue.