### PR TITLE
Allow fps() to dynamically get FPS value without having to call stop()

### DIFF
--- a/imutils/video/fps.py
+++ b/imutils/video/fps.py
@@ -26,7 +26,10 @@ class FPS:
 	def elapsed(self):
 		# return the total number of seconds between the start and
 		# end interval
-		return (self._end - self._start).total_seconds()
+		if self._end is None:
+			return (datetime.datetime.now() - self._start).total_seconds()
+		else:
+			return (self._end - self._start).total_seconds()
 
 	def fps(self):
 		# compute the (approximate) frames per second


### PR DESCRIPTION
Yet another attempt.