### PR TITLE
Strong typed var that was causing error.

### DIFF
--- a/imutils/face_utils/facealigner.py
+++ b/imutils/face_utils/facealigner.py
@@ -61,8 +61,8 @@ class FaceAligner:
 
 		# compute center (x, y)-coordinates (i.e., the median point)
 		# between the two eyes in the input image
-		eyesCenter = ((leftEyeCenter[0] + rightEyeCenter[0]) // 2,
-			(leftEyeCenter[1] + rightEyeCenter[1]) // 2)
+		eyesCenter = (int((leftEyeCenter[0] + rightEyeCenter[0]) // 2),
+			(int(leftEyeCenter[1] + rightEyeCenter[1]) // 2))
 
 		# grab the rotation matrix for rotating and scaling the face
 		M = cv2.getRotationMatrix2D(eyesCenter, angle, scale)


### PR DESCRIPTION
When used on Python3, this utility broke with the error: 
`"TypeError: Can't parse 'center'. Sequence item with index 0 has a wrong type"`

I debugged it and found that the error was the absence of typing on the variable eyesCenter, so I strong typed the var that was causing the error.