### PR TITLE
Fix【wrong type】about eyesCenter

### DIFF
--- a/imutils/face_utils/facealigner.py
+++ b/imutils/face_utils/facealigner.py
@@ -61,8 +61,7 @@ class FaceAligner:
 
 		# compute center (x, y)-coordinates (i.e., the median point)
 		# between the two eyes in the input image
-		eyesCenter = ((leftEyeCenter[0] + rightEyeCenter[0]) // 2,
-			(leftEyeCenter[1] + rightEyeCenter[1]) // 2)
+		eyesCenter = (int((leftEyeCenter[0] + rightEyeCenter[0]) // 2), int((leftEyeCenter[1] + rightEyeCenter[1]) // 2))
 
 		# grab the rotation matrix for rotating and scaling the face
 		M = cv2.getRotationMatrix2D(eyesCenter, angle, scale)


### PR DESCRIPTION
Error Info:【TypeError: Can't parse 'center'. Sequence item with index 0 has a wrong type】
Cause by: eyesCenter's element's type is numpy.int64, which is need an int type
Solved by: change numpy.int64 into int type 
sources: eyesCenter = ((leftEyeCenter[0] + rightEyeCenter[0]) // 2, (leftEyeCenter[1] + rightEyeCenter[1]) // 2) ->
              eyesCenter = (int((leftEyeCenter[0] + rightEyeCenter[0]) // 2), int((leftEyeCenter[1] + rightEyeCenter[1]) // 2))