### PR TITLE
Remove dependency on scipy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For more information, along with a detailed code review check out the following 
 - [http://www.pyimagesearch.com/2015/08/10/checking-your-opencv-version-using-python/](http://www.pyimagesearch.com/2015/08/10/checking-your-opencv-version-using-python/)
 
 ## Installation
-Provided you already have NumPy, SciPy, Matplotlib, and OpenCV already installed, the `imutils` package is completely `pip`-installable:
+Provided you already have NumPy, Matplotlib, and OpenCV already installed, the `imutils` package is completely `pip`-installable:
 
 <pre>$ pip install imutils</pre>
 

--- a/imutils/perspective.py
+++ b/imutils/perspective.py
@@ -26,7 +26,7 @@ def order_points(pts):
     # top-left and right-most points; by the Pythagorean
     # theorem, the point with the largest distance will be
     # our bottom-right point
-    D = dist.cdist(tl[np.newaxis], rightMost, "euclidean")[0]
+    D = np.linalg.norm(np.subtract(tl[np.newaxis], rightMost), axis=1)
     (br, tr) = rightMost[np.argsort(D)[::-1], :]
 
     # return the coordinates in top-left, top-right,

--- a/imutils/perspective.py
+++ b/imutils/perspective.py
@@ -2,7 +2,6 @@
 # website:   http://www.pyimagesearch.com
 
 # import the necessary packages
-from scipy.spatial import distance as dist
 import numpy as np
 import cv2
 


### PR DESCRIPTION
`imutils` depends on `scipy` just for calculating Euclidean distance in perspective.py. This dependency was adding significant size to our OpenCV layer for aws lambda functions that have a limit of 250 MB on package size when uncompressed.

scipy installed size ~ 185 MB
zipped size ~ 58 MB

Current changes utilize numpy to achieve the same so that scipy dependency can be removed.

This resolves the issue: https://github.com/PyImageSearch/imutils/issues/175