### PR TITLE
fix FileVideoStream running even if stopped

### DIFF
--- a/imutils/video/filevideostream.py
+++ b/imutils/video/filevideostream.py
@@ -81,7 +81,7 @@ class FileVideoStream:
 	# not take into account if the producer has reached end of
 	# file stream.
 	def running(self):
-		return self.more() or not self.stopped
+		return self.more() and not self.stopped
 
 	def more(self):
 		# return True if there are still frames in the queue. If stream is not stopped, try to wait a moment


### PR DESCRIPTION
I believe when the stream is stopped for whatever reason `running()` should return `False`, since otherwise it does not fix the problem of `more()` returning `True` even if the file end has been reached.

This is quiet an annoying problem since it forces the client to check for `None` frames as has been noted in #251.