### PR TITLE
Fix deprecated metadata.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Hyphens in metadata names causes syntax errors during build because they are no longer allowed. Underscores are required now.