### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     description='A series of convenience functions to make basic image processing functions such as translation, rotation, resizing, skeletonization, displaying Matplotlib images, sorting contours, detecting edges, and much more easier with OpenCV and both Python 2.7 and Python 3.',
     author='Adrian Rosebrock',
     author_email='adrian@pyimagesearch.com',
+    license="MIT",
     url='https://github.com/jrosebr1/imutils',
     download_url='https://github.com/jrosebr1/imutils/tarball/0.1',
     keywords=['computer vision', 'image processing', 'opencv', 'matplotlib'],


### PR DESCRIPTION
This helps automatic license checkers like pip-licenses to identify the right license for this project

Closes #292 